### PR TITLE
change branch name from master to main in url

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,13 +16,13 @@ https://mybinder.org/
 by clicking on the binder badges below:
 
 * Basic introduction:
-[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/JeffFessler/mirt-demo/master?filepath=isbi-19%2F00-intro.ipynb)
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/JeffFessler/mirt-demo/main?filepath=isbi-19%2F00-intro.ipynb)
 
 * MRI compressed sensing reconstruction demo:
-[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/JeffFessler/mirt-demo/master?filepath=isbi-19%2F01-recon.ipynb)
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/JeffFessler/mirt-demo/main?filepath=isbi-19%2F01-recon.ipynb)
 
 * Dynamic MRI with golden-angle radial sampling reconstruction demo:
-[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/JeffFessler/mirt-demo/master?filepath=mri%2Fmri-sim-2d%2Bt.ipynb)
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/JeffFessler/mirt-demo/main?filepath=mri%2Fmri-sim-2d%2Bt.ipynb)
 
 You can also view the notebook code directly:
 * [isbi-19 demos](https://github.com/JeffFessler/mirt-demo/blob/master/isbi-19/)


### PR DESCRIPTION
Due to GitHub recent changes, currently binder cannot open the file since the branch name has been changed. Fixed by simply updating the branch name to main.